### PR TITLE
fix: replay button for auto play mode

### DIFF
--- a/snake_game/simplified_snake_game.py
+++ b/snake_game/simplified_snake_game.py
@@ -270,16 +270,15 @@ def pausemenu():
         
         pausetitletext = gameDisplay.blit(pausetitleImg, (400-(pausetitleImg.get_width()/2),220))
         
+        resumeButton  = Button(resumeImg,100,420,Button_width,Button_height,clickresumeImg,100,418,resumegame)
+        quitButton = Button(quitImg,550,420,Button_width,Button_height,clickQuitImg,550,418,mainmenu)
         if gameChoice == 1:
-            resumeButton  = Button(resumeImg,100,420,Button_width,Button_height,clickresumeImg,100,418,resumegame)
             restartButton = Button(restartImg,260,420,Button_width,Button_height,clickrestartImg,260,418,main)
             saveButton = Button(saveImg,415,420,Button_width,Button_height,clicksaveImg,415,418,savegame)
-            quitButton = Button(quitImg,550,420,Button_width,Button_height,clickQuitImg,550,418,mainmenu)
-        
-        else:
-            resumeButton  = Button(resumeImg,100,420,Button_width,Button_height,clickresumeImg,100,418,resumegame)
+        elif gameChoice == 2:
             restartButton = Button(restartImg,330,420,Button_width,Button_height,clickrestartImg,330,418,dualgame)
-            quitButton = Button(quitImg,550,420,Button_width,Button_height,clickQuitImg,550,418,mainmenu)
+        else:
+            restartButton = Button(restartImg,330,420,Button_width,Button_height,clickrestartImg,330,418,autogame)
 
         pygame.display.update()
         clock.tick(15)


### PR DESCRIPTION
As I mentioned in the issue #3 , the auto play's "restart" button launched a new dual play game instead of a new auto play game.

Here's how I fixed the issue by adding an "elif" condition in the pauseMenu() function.
I also refactorized some part of the function to optimize the code.

Here's the demo link after my modifications : https://www.loom.com/share/35079253aa1b4f07bd95b5175d9fcc24
Don't hesitate to contact me if you need further informations